### PR TITLE
fix lipgloss style ui-misalignment

### DIFF
--- a/view.go
+++ b/view.go
@@ -28,6 +28,12 @@ func (m *Model) View() string {
 	m.input.SetHeight(m.height * 20 / 100)
 	m.input.SetWidth((m.width * 100 / 100) - 4)
 
+	feedStyle := lipgloss.NewStyle().
+		BorderStyle(lipgloss.RoundedBorder()).
+		BorderForeground(screenBorderColor)
+
+	verticalFrameSize, horizontalFrameSize := feedStyle.GetFrameSize()
+
 	return lipgloss.JoinVertical(lipgloss.Center,
 		lipgloss.JoinHorizontal(lipgloss.Left,
 			lipgloss.NewStyle().
@@ -35,12 +41,7 @@ func (m *Model) View() string {
 				BorderStyle(lipgloss.RoundedBorder()).
 				BorderForeground(listBorderColor).
 				Render(m.sidebar.table.View()),
-			lipgloss.NewStyle().
-				Height(screenHeight).
-				Width(screenWidth).
-				BorderStyle(lipgloss.RoundedBorder()).
-				BorderForeground(screenBorderColor).
-				Render(m.page.View(screenWidth, screenHeight)),
+			feedStyle.Render(m.page.View(screenWidth-horizontalFrameSize, screenHeight-verticalFrameSize)),
 		),
 		lipgloss.JoinHorizontal(lipgloss.Center,
 			lipgloss.NewStyle().


### PR DESCRIPTION
Hello,

This fixes the ui-misalignment issue for me locally. I tested with Alacritty and by zooming in and out. I could zoom in and out without experiencing any of the problems mentioned by you in issue #1, even when scrolling very fast across many notes.

The reason for the misalignment (if I am correct) is that lipgloss is causing the list to run higher than the vertical height of the terminal. There could still be some adjustments here but please test my code and let me know if it fixes the issue.

I read up on a similar issue here: https://github.com/charmbracelet/bubbletea/discussions/240