### PR TITLE
fixes horizontal feed jumping when scrolling

### DIFF
--- a/note_item_delegate.go
+++ b/note_item_delegate.go
@@ -40,7 +40,7 @@ func newNoteItemDelegate() *NoteItemDelegate {
 				Align(lipgloss.Right).
 				Foreground(styles.dimmed),
 			TextStyle: lipgloss.NewStyle().
-				Padding(0, 5, 0, 2),
+				Padding(0, 0, 0, 2),
 		},
 	}
 


### PR DESCRIPTION
This fixes the horizontal jumping when scrolling past large notes for me locally. When we use `GetFrameSize()` to dynamically calculate it seems we no longer need bottom padding in `TextStyle` in the file `note_item_delegate.go`. 

I didn't observe any new artifacts, but let me know if you spot any and if this fixes your issue.

P.S. I can take a look at the empty feed width issue as well, I didn't find the root cause for it yet. Might want to create another issue for it and I'll cross it off later when I am able. I'm out of time for today.