### PR TITLE
Fix/misalignment

### DIFF
--- a/note_item_delegate.go
+++ b/note_item_delegate.go
@@ -123,6 +123,7 @@ func (nid *NoteItemDelegate) Render(w io.Writer, m list.Model, index int, li lis
 
 	fmt.Fprint(w,
 		noteStyles.TextStyle.
+			Width(m.Width()).
 			Render(text),
 	)
 }

--- a/view.go
+++ b/view.go
@@ -5,8 +5,7 @@ import (
 )
 
 const (
-	listWidth = 15
-
+	listWidth           = 15
 	activeBorderColor   = lipgloss.Color("255")
 	inactiveBorderColor = lipgloss.Color("238")
 )
@@ -29,6 +28,8 @@ func (m *Model) View() string {
 	m.input.SetWidth((m.width * 100 / 100) - 4)
 
 	feedStyle := lipgloss.NewStyle().
+		Width(screenWidth).
+		Height(screenHeight).
 		BorderStyle(lipgloss.RoundedBorder()).
 		BorderForeground(screenBorderColor)
 


### PR DESCRIPTION
I restored the width & height to `feedStyle`, which fixes border sizing even if there are no feed items. This PR also fixes cases where there are really long URLs. I did  this by adding the `m.Width()` to the `notStyles.TextStyle.Width()` inside the `nid Render(...)`.

I tested this in Alacritty, Xterm and Xcfe terminal with no artifacts. I followed 0xtr, Dergigi and you. This should be the one that fixes #1 completely. But you know this project best, let me know if you find any other issues.