### PR TITLE
instance: use Pleroma-compatible version string

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -42,7 +42,7 @@ func instanceHandler(w http.ResponseWriter, r *http.Request) {
 		ShortDescription: "nostr homeserver",
 		Registrations:    false,
 		MaxTootChars:     90000,
-		Version:          "1",
+		Version:          "2.7.2 (compatible; bisu 0.0.0)",
 		Rules:            []any{},
 		Urls: urls{
 			StreamingAPI: "ws://" + srv.Addr,


### PR DESCRIPTION
Soapbox parses the version string and uses it for feature detection. The version string is similar to a User-Agent. The first value is the _Mastodon version_ this thing claims to have API compatibility with (we don't normally use that value, so `0.0.0` is fine). The second value is the actual version of bisu itself. This will enable us to add special support for bisu in Soapbox.